### PR TITLE
Xsw 1948  remove unexpected banners

### DIFF
--- a/docs/samples/add-directory-extensions-to-azure-ad-connect/index.html
+++ b/docs/samples/add-directory-extensions-to-azure-ad-connect/index.html
@@ -1322,7 +1322,7 @@
             margin-left: 50px
         }
     </style>
-    <div class="portlet-msg-alert hidden" id="global-alert-msg"> Sample Exchange is in maintenance mode from April 19th
+    <div class="portlet-msg-alert hidden" id="global-alert-msg" style="display: none;"> Sample Exchange is in maintenance mode from April 19th
         to May 6th. Downloads are still available. More news to come in May! <a class="cancel"><i
                 class="fa fa-times"></i></a> </div>
     <script

--- a/docs/samples/add-directory-extensions-to-azure-ad-connect/index.html
+++ b/docs/samples/add-directory-extensions-to-azure-ad-connect/index.html
@@ -1322,9 +1322,6 @@
             margin-left: 50px
         }
     </style>
-    <div class="portlet-msg-alert hidden" id="global-alert-msg" style="display: none;"> Sample Exchange is in maintenance mode from April 19th
-        to May 6th. Downloads are still available. More news to come in May! <a class="cancel"><i
-                class="fa fa-times"></i></a> </div>
     <script
         type="text/javascript">$(function () { if (!$.cookie("GLOBAL_ALERT_DISMISSED")) { $("#global-alert-msg").removeClass("hidden") } $("#global-alert-msg .cancel").on("click", function () { $("#global-alert-msg").remove(); $.cookie("GLOBAL_ALERT_DISMISSED", true, { path: "/" }) }); if ($("#global-alert-msg").length == 1 && $("#global-alert-msg").css("display") == "block") { $(".vmware body").css("padding-top", 54); if ($(".navbar.navbar-static-top.dockbar").length == 0) { $("#global-alert-msg").css("margin-top", "0px") } } else { $(".vmware body").css("padding-top", 0) } $(".portlet-msg-alert .fa-times").on("click", function () { $(".vmware body").css("padding-top", 0) }) });</script>
     <script src="/vmware-code-theme/js/body.js" type="text/javascript"></script>


### PR DESCRIPTION
XSW-1948 Remove unexpected green banner that starts with text "Sample Exchange is in maintenance mode"

index.html 
- deleted the entire < div > item

Note: we cannot preview the GitHub Pages result until this is merged
